### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jshint-stylish": "1.0.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Update peerDependencies to be compatible with the new Grunt v1.0.

For more info: http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies

(P.S. Close this PR if it is a mistake, sorry)
